### PR TITLE
feat(payments): support replicating payments for multiple selected dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Need to chat? Feel free to drop me a line via [Email](mailto:novaardiansyah78@gm
 
 ## Project Status
 
-![stages](https://img.shields.io/badge/stages-development-informational)
+![stages](https://img.shields.io/badge/stages-production-informational)
 ![Laravel](https://img.shields.io/badge/Laravel-12-blue)
 ![Filament](https://img.shields.io/badge/Filament-5-blue)
 ![PHP](https://img.shields.io/badge/PHP-^8.2-blue)

--- a/app/Filament/Resources/Payments/Actions/ReplicateAction.php
+++ b/app/Filament/Resources/Payments/Actions/ReplicateAction.php
@@ -1,10 +1,24 @@
 <?php
 
+/*
+ * Project Name: personal-v4
+ * File: ReplicateAction.php
+ * Created Date: June 01, 2026
+ *
+ * Author: Nova Ardiansyah admin@novaardiansyah.id
+ * Website: https://novaardiansyah.id
+ * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
+ *
+ * Copyright (c) 2026 Nova Ardiansyah, Org
+ */
+
 namespace App\Filament\Resources\Payments\Actions;
 
 use App\Models\Payment;
+use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Textarea;
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\Width;
@@ -22,44 +36,59 @@ class ReplicateAction
 			->modalHeading(fn(Payment $record): string => 'Replicate Payment ' . $record->code)
 			->modalWidth(Width::Large)
 			->schema([
-				DatePicker::make('date')
-					->label('Date')
-					->required()
-					->displayFormat('M d, Y')
-					->closeOnDateSelection()
-					->native(false),
-
 				Textarea::make('name')
 					->label('Notes')
 					->nullable()
 					->rows(3),
+
+				Repeater::make('dates')
+					->label('Dates')
+					->required()
+					->minItems(1)
+					->reorderable(false)
+					->schema([
+						DatePicker::make('date')
+							->label('Date')
+							->required()
+							->displayFormat('M d, Y')
+							->closeOnDateSelection()
+							->native(false),
+					]),
 			])
 			->fillForm(function (Payment $record): array {
 				return [
-					'date' => $record->date,
+					'dates' => [
+						['date' => Carbon::parse($record->date)->addDay()->toDateString()],
+					],
 					'name' => $record->name,
 				];
 			})
 			->action(function (Payment $record, array $data): void {
-				$replicated = $record->replicate();
+				$count = 0;
 
-				$replicated->date = $data['date'];
-				$replicated->name = $data['name'];
-				$replicated->save();
+				foreach ($data['dates'] as $dateEntry) {
+					$replicated = $record->replicate();
 
-				foreach ($record->items as $item) {
-					$replicated->items()->attach($item->id, [
-						'item_code' => $item->pivot->item_code,
-						'quantity'  => $item->pivot->quantity,
-						'price'     => $item->pivot->price,
-						'total'     => $item->pivot->total,
-					]);
+					$replicated->date = $dateEntry['date'];
+					$replicated->name = $data['name'];
+					$replicated->save();
+
+					foreach ($record->items as $item) {
+						$replicated->items()->attach($item->id, [
+							'item_code' => $item->pivot->item_code,
+							'quantity'  => $item->pivot->quantity,
+							'price'     => $item->pivot->price,
+							'total'     => $item->pivot->total,
+						]);
+					}
+
+					$count++;
 				}
 
 				Notification::make()
 					->success()
 					->title('Payment Replicated')
-					->body('Payment has been replicated successfully.')
+					->body("Payment has been replicated x{$count} successfully.")
 					->send();
 			});
 	}


### PR DESCRIPTION
- Replaced the single date picker with a repeater of date pickers in the replicate action.
- Loop over each selected date to create a replicated payment entry for each date.