### PR TITLE
feat(payment): enhance draft payment reminder job

### DIFF
--- a/app/Jobs/PaymentResource/DraftPaymentReminderJob.php
+++ b/app/Jobs/PaymentResource/DraftPaymentReminderJob.php
@@ -44,32 +44,11 @@ class DraftPaymentReminderJob implements ShouldQueue
       ->where('date', $today)
       ->get();
 
-    if ($draftPayments->isEmpty()) {
-      $defaultLog = array_merge($defaultLog, [
-        'description'  => 'DraftPaymentReminderJob() No drafts found for ' . $today,
-        'subject_type' => ActivityLog::class,
-        'subject_id'   => $startLog->id,
-      ]);
-
-      saveActivityLog($defaultLog);
-      return;
-    }
-
     $draftExpense = $draftPayments->where('type_id', PaymentType::EXPENSE)->sum('amount');
     $draftIncome  = $draftPayments->where('type_id', PaymentType::INCOME)->sum('amount');
     $draftOther   = $draftPayments->whereNotIn('type_id', [PaymentType::EXPENSE, PaymentType::INCOME])->sum('amount');
 
-    $pdfParams = [
-			'title'      => 'Laporan Draft Transaksi',
-			'start_date' => $today,
-			'end_date'   => $today,
-			'now'        => $now,
-			'user'       => $causer,
-			'is_draft'   => true,
-    ];
-
-    $pdf  = PaymentService::make_pdf($pdfParams);
-    $date = carbonTranslatedFormat($now, 'd F Y');
+    $date = carbonTranslatedFormat($now, 'd F Y', 'id');
 
     $data = [
       'log_name'      => 'draft_payment_reminder',
@@ -82,10 +61,25 @@ class DraftPaymentReminderJob implements ShouldQueue
       'draft_income'  => $draftIncome,
       'draft_other'   => $draftOther,
       'created_at'    => $now,
-      'attachments'   => [
-        $pdf['fullpath'],
-      ],
+      'attachments'   => [],
     ];
+
+    if ($draftPayments->isNotEmpty()) {
+      $pdfParams = [
+        'title'      => 'Laporan Draft Transaksi',
+        'start_date' => $today,
+        'end_date'   => $today,
+        'now'        => $now,
+        'user'       => $causer,
+        'is_draft'   => true,
+      ];
+
+      $pdf = PaymentService::make_pdf($pdfParams);
+
+      $data['attachments'] = [
+        $pdf['fullpath'],
+      ];
+    }
 
     Mail::to($data['email'])->queue(new DraftPaymentReminderMail($data));
     $html = (new DraftPaymentReminderMail($data))->render();

--- a/resources/views/payment-resource/mails/draft-payment-reminder-mail.blade.php
+++ b/resources/views/payment-resource/mails/draft-payment-reminder-mail.blade.php
@@ -9,19 +9,23 @@
 @endsection
 
 @section('content')
-  <p>Berikut adalah daftar transaksi draft yang dijadwalkan untuk hari ini <strong>{{ $data['date'] }}</strong>. Silakan tinjau dan lakukan tindakan yang diperlukan.</p>
+  @if($data['draft_count'] > 0)
+    <p>Berikut adalah daftar transaksi draft yang dijadwalkan untuk hari ini <strong>{{ $data['date'] }}</strong>. Silakan tinjau dan lakukan tindakan yang diperlukan.</p>
 
-  <div class="card mb-2">
-    <div class="group">
-      <h4>Ringkasan Draft</h4>
-      <ul class="list-flush">
-        <li><strong>Jumlah Transaksi</strong>: {{ $data['draft_count'] }} transaksi</li>
-        <li><strong>Total Pengeluaran</strong>: {{ toIndonesianCurrency($data['draft_expense']) }}</li>
-        <li><strong>Total Pendapatan</strong>: {{ toIndonesianCurrency($data['draft_income']) }}</li>
-        <li><strong>Total Lainnya</strong>: {{ toIndonesianCurrency($data['draft_other']) }}</li>
-      </ul>
+    <div class="card mb-2">
+      <div class="group">
+        <h4>Ringkasan Draft</h4>
+        <ul class="list-flush">
+          <li><strong>Jumlah Transaksi</strong>: {{ $data['draft_count'] }} transaksi</li>
+          <li><strong>Total Pengeluaran</strong>: {{ toIndonesianCurrency($data['draft_expense']) }}</li>
+          <li><strong>Total Pendapatan</strong>: {{ toIndonesianCurrency($data['draft_income']) }}</li>
+          <li><strong>Total Lainnya</strong>: {{ toIndonesianCurrency($data['draft_other']) }}</li>
+        </ul>
+      </div>
     </div>
-  </div>
 
-  <p>Detail lengkap transaksi draft terlampir dalam file PDF.</p>
+    <p>Detail lengkap transaksi draft terlampir dalam file PDF.</p>
+  @else
+    <p>Tidak ada transaksi draft yang ditemukan untuk hari ini <strong>{{ $data['date'] }}</strong>.</p>
+  @endif
 @endsection


### PR DESCRIPTION
- Update DraftPaymentReminderJob to always send notification emails.
- Add message indicating no drafts are found when the list is empty.
- Avoid attaching a PDF document when there are no draft payments.