### PR TITLE
feat(debt): adjust debt resource form fields

### DIFF
--- a/app/Filament/Resources/Debts/Schemas/DebtForm.php
+++ b/app/Filament/Resources/Debts/Schemas/DebtForm.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * Project Name: personal-v4
+ * File: DebtForm.php
+ * Created Date: Thursday June 25th 2026
+ * 
+ * Author: Nova Ardiansyah admin@novaardiansyah.id
+ * Website: https://novaardiansyah.id
+ * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
+ * 
+ * Copyright (c) 2026 Nova Ardiansyah, Org
+ */
+
 namespace App\Filament\Resources\Debts\Schemas;
 
 use App\Models\PaymentAccount;
@@ -15,92 +27,101 @@ use Filament\Schemas\Schema;
 
 class DebtForm
 {
-  public static function configure(Schema $schema): Schema
-  {
-    return $schema
-      ->components([
-        Section::make([
-          Grid::make([
-            'sm' => 2,
-            'xs' => 1
-          ])
-            ->columnSpanFull()
-            ->schema([
-              TextInput::make('platform_name')
-                ->required(),
-              TextInput::make('name')
-                ->required(),
-              TextInput::make('principal_amount')
-                ->required()
-                ->numeric()
-                ->live(onBlur: true)
-                ->afterStateUpdated(function (Get $get, Set $set, ?string $state) {
-                  $principal = (float) $state;
-                  $adminFee = (float) $get('admin_fee');
-                  $set('disbursement_amount', $principal - $adminFee);
-                }),
-              TextInput::make('admin_fee')
-                ->required()
-                ->numeric()
-                ->default(0)
-                ->live(onBlur: true)
-                ->afterStateUpdated(function (Get $get, Set $set, ?string $state) {
-                  $principal = (float) $get('principal_amount');
-                  $adminFee = (float) $state;
-                  $set('disbursement_amount', $principal - $adminFee);
-                }),
-              TextInput::make('disbursement_amount')
-                ->required()
-                ->numeric()
-                ->readOnly(),
-              TextInput::make('interest_rate')
-                ->required()
-                ->numeric()
-                ->default(0),
-              TextInput::make('service_fee_rate')
-                ->required()
-                ->numeric()
-                ->default(0),
-              TextInput::make('tenor')
-                ->required()
-                ->numeric()
-                ->default(1),
-              DatePicker::make('start_date')
-                ->required()
-                ->default(now())
-                ->native(false),
-            ])
-        ])
-          ->description('Debt Information')
-          ->columnSpan(['sm' => 3, 'md' => 2]),
+	public static function configure(Schema $schema): Schema
+	{
+		return $schema
+			->components([
+				Section::make([
+					Grid::make([
+						'sm' => 2,
+						'xs' => 1
+					])
+						->columnSpanFull()
+						->schema([
+							TextInput::make('platform_name')
+								->required(),
+							TextInput::make('name')
+								->required(),
+							TextInput::make('principal_amount')
+								->required()
+								->numeric()
+								->live(onBlur: true)
+								->hint(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0)))
+								->afterStateUpdated(function (Get $get, Set $set, ?string $state) {
+									$principal = (float) $state;
+									$adminFee = (float) $get('admin_fee');
+									$set('disbursement_amount', $principal - $adminFee);
+								}),
+							TextInput::make('admin_fee')
+								->required()
+								->numeric()
+								->default(0)
+								->live(onBlur: true)
+								->hint(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0)))
+								->afterStateUpdated(function (Get $get, Set $set, ?string $state) {
+									$principal = (float) $get('principal_amount');
+									$adminFee = (float) $state;
+									$set('disbursement_amount', $principal - $adminFee);
+								}),
+							TextInput::make('disbursement_amount')
+								->required()
+								->numeric()
+								->readOnly()
+								->hint(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+							TextInput::make('interest_rate')
+								->required()
+								->numeric()
+								->default(0)
+								->suffix('%'),
+							TextInput::make('service_fee_rate')
+								->required()
+								->numeric()
+								->default(0)
+								->suffix('%'),
+							TextInput::make('tenor')
+								->required()
+								->numeric()
+								->default(1),
+							DatePicker::make('start_date')
+								->required()
+								->default(now())
+								->native(false),
+						])
+				])
+					->description('Debt Information')
+					->columnSpan(['sm' => 3, 'md' => 2]),
 
-        Section::make([
-          TextInput::make('code')
-            ->label('Debt ID')
-            ->placeholder('Auto Generated')
-            ->disabled()
-            ->visibleOn('edit'),
-          Select::make('payment_account_id')
-            ->label('Disbursement Account')
-            ->relationship('payment_account', 'name')
-            ->native(false)
-            ->preload()
-            ->searchable()
-            ->required(),
-          Select::make('status')
-            ->options([
-              'ongoing' => 'Ongoing',
-              'paid' => 'Paid',
-            ])
-            ->default('ongoing')
-            ->required(),
-          Textarea::make('description')
-            ->rows(3),
-        ])
-          ->description('Details')
-          ->columns(1)
-          ->columnSpan(['sm' => 3, 'md' => 1])
-      ])
-      ->columns(3);
-  }
+				Section::make([
+					TextInput::make('code')
+						->label('Debt ID')
+						->placeholder('Auto Generated')
+						->disabled()
+						->visibleOn('edit'),
+					Select::make('payment_account_id')
+						->label('Disbursement Account')
+						->relationship('payment_account', 'name', fn($query) => $query->where('user_id', auth()->id()))
+						->native(false)
+						->preload()
+						->searchable()
+						->required()
+						->live(onBlur: true)
+						->hint(fn(?string $state) => toIndonesianCurrency(PaymentAccount::find($state)?->deposit ?? 0)),
+					Select::make('status')
+						->options([
+							'ongoing' => 'Ongoing',
+							'paid' => 'Paid',
+						])
+						->native(false)
+						->preload()
+						->default('ongoing')
+						->required(),
+					Textarea::make('description')
+						->rows(3),
+				])
+					->description('Details')
+					->columns(1)
+					->columnSpan(['sm' => 3, 'md' => 1])
+			])
+			->columns(3);
+	}
 }


### PR DESCRIPTION
- Add currency formatting hints to nominal input fields.
- Add percent suffix to interest rate and service fee rate fields.
- Disable native select and enable preload for the status field.
- Filter disbursement accounts by logged-in user and show balance hints.