### PR TITLE
feat(debt): create infolist schema and view actions

### DIFF
--- a/app/Filament/Resources/Debts/Pages/ViewDebt.php
+++ b/app/Filament/Resources/Debts/Pages/ViewDebt.php
@@ -1,19 +1,37 @@
 <?php
 
+/*
+ * Project Name: personal-v4
+ * File: ViewDebt.php
+ * Created Date: Thursday June 25th 2026
+ * 
+ * Author: Nova Ardiansyah admin@novaardiansyah.id
+ * Website: https://novaardiansyah.id
+ * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
+ * 
+ * Copyright (c) 2026 Nova Ardiansyah, Org
+ */
+
 namespace App\Filament\Resources\Debts\Pages;
 
 use App\Filament\Resources\Debts\DebtResource;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewDebt extends ViewRecord
 {
-    protected static string $resource = DebtResource::class;
+	protected static string $resource = DebtResource::class;
 
-    protected function getHeaderActions(): array
-    {
-        return [
-            EditAction::make(),
-        ];
-    }
+	protected function getHeaderActions(): array
+	{
+		return [
+			EditAction::make(),
+			DeleteAction::make(),
+			ForceDeleteAction::make(),
+			RestoreAction::make(),
+		];
+	}
 }

--- a/app/Filament/Resources/Debts/Schemas/DebtInfolist.php
+++ b/app/Filament/Resources/Debts/Schemas/DebtInfolist.php
@@ -1,16 +1,102 @@
 <?php
 
+/*
+ * Project Name: personal-v4
+ * File: DebtInfolist.php
+ * Created Date: Thursday June 25th 2026
+ * 
+ * Author: Nova Ardiansyah admin@novaardiansyah.id
+ * Website: https://novaardiansyah.id
+ * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
+ * 
+ * Copyright (c) 2026 Nova Ardiansyah, Org
+ */
+
 namespace App\Filament\Resources\Debts\Schemas;
 
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 
 class DebtInfolist
 {
-    public static function configure(Schema $schema): Schema
-    {
-        return $schema
-            ->components([
-                //
-            ]);
-    }
+	public static function configure(Schema $schema): Schema
+	{
+		return $schema
+			->components([
+				Section::make('')
+					->description('Debt Information')
+					->schema([
+						TextEntry::make('code')
+							->label('Debt ID')
+							->copyable()
+							->badge()
+							->color('info'),
+						TextEntry::make('platform_name')
+							->label('Platform')
+							->placeholder('N/A'),
+						TextEntry::make('name')
+							->label('Name')
+							->placeholder('N/A'),
+						TextEntry::make('status')
+							->label('Status')
+							->badge()
+							->color(fn(string $state): string => match ($state) {
+								'paid' => 'success',
+								'ongoing' => 'warning',
+								default => 'primary'
+							}),
+						TextEntry::make('principal_amount')
+							->label('Principal Amount')
+							->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0)))
+							->weight('bold'),
+						TextEntry::make('admin_fee')
+							->label('Admin Fee')
+							->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+						TextEntry::make('disbursement_amount')
+							->label('Net Disbursement')
+							->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+						TextEntry::make('interest_rate')
+							->label('Interest Rate')
+							->suffix('%'),
+						TextEntry::make('service_fee_rate')
+							->label('Service Fee Rate')
+							->suffix('%'),
+						TextEntry::make('tenor')
+							->label('Tenor')
+							->formatStateUsing(fn($state) => $state . ' Months'),
+						TextEntry::make('start_date')
+							->label('Start Date')
+							->date('M d, Y'),
+						TextEntry::make('payment_account.name')
+							->label('Disbursement Account')
+							->placeholder('N/A'),
+						TextEntry::make('description')
+							->label('Description')
+							->placeholder('No description available')
+							->columnSpanFull(),
+					])
+					->columns(['xl' => 3, '2xl' => 4])
+					->columnSpan(['sm' => 3, 'md' => 2]),
+
+				Section::make('')
+					->description('System Information')
+					->schema([
+						TextEntry::make('created_at')
+							->label('Created At')
+							->dateTime(),
+						TextEntry::make('updated_at')
+							->label('Last Updated')
+							->dateTime()
+							->sinceTooltip(),
+						TextEntry::make('deleted_at')
+							->label('Deleted At')
+							->dateTime()
+							->placeholder('Active'),
+					])
+					->columns(1)
+					->columnSpan(['sm' => 3, 'md' => 1]),
+			])
+			->columns(3);
+	}
 }


### PR DESCRIPTION
- Create the infolist configuration for the view action in the debt resource.
- Display structured debt details and system information on the view page.
- Add header actions for edit, delete, force delete, and restore to the view page.