### PR TITLE
refactor(debt-installments): tidy up DebtInstallmentResource module

### DIFF
--- a/app/Filament/Resources/DebtInstallments/DebtInstallmentResource.php
+++ b/app/Filament/Resources/DebtInstallments/DebtInstallmentResource.php
@@ -14,7 +14,6 @@
 
 namespace App\Filament\Resources\DebtInstallments;
 
-use App\Filament\Resources\DebtInstallments\Pages\CreateDebtInstallment;
 use App\Filament\Resources\DebtInstallments\Pages\EditDebtInstallment;
 use App\Filament\Resources\DebtInstallments\Pages\ListDebtInstallments;
 use App\Filament\Resources\DebtInstallments\Pages\ViewDebtInstallment;
@@ -31,47 +30,44 @@ use UnitEnum;
 
 class DebtInstallmentResource extends Resource
 {
-	protected static ?string $model = DebtInstallment::class;
+  protected static ?string $model = DebtInstallment::class;
 
-	protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCurrencyBangladeshi;
+  protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCurrencyBangladeshi;
 
-	protected static string|UnitEnum|null $navigationGroup = 'Payments';
+  protected static string|UnitEnum|null $navigationGroup = 'Payments';
 
-	protected static ?string $navigationParentItem = 'Debts';
+  protected static ?string $navigationParentItem = 'Debts';
 
-	protected static ?int $navigationSort = 11;
+  protected static ?int $navigationSort = 11;
 
-	protected static ?string $recordTitleAttribute = 'installment_number';
+  protected static ?string $recordTitleAttribute = 'debt.name';
 
-	public static function form(Schema $schema): Schema
-	{
-		return DebtInstallmentForm::configure($schema);
-	}
+  public static function form(Schema $schema): Schema
+  {
+    return DebtInstallmentForm::configure($schema);
+  }
 
-	public static function infolist(Schema $schema): Schema
-	{
-		return DebtInstallmentInfolist::configure($schema);
-	}
+  public static function infolist(Schema $schema): Schema
+  {
+    return DebtInstallmentInfolist::configure($schema);
+  }
 
-	public static function table(Table $table): Table
-	{
-		return DebtInstallmentsTable::configure($table);
-	}
+  public static function table(Table $table): Table
+  {
+    return DebtInstallmentsTable::configure($table);
+  }
 
-	public static function getRelations(): array
-	{
-		return [
-			//
-		];
-	}
+  public static function getRelations(): array
+  {
+    return [];
+  }
 
-	public static function getPages(): array
-	{
-		return [
-			'index' => ListDebtInstallments::route('/'),
-			'create' => CreateDebtInstallment::route('/create'),
-			'view' => ViewDebtInstallment::route('/{record}'),
-			'edit' => EditDebtInstallment::route('/{record}/edit'),
-		];
-	}
+  public static function getPages(): array
+  {
+    return [
+      'index' => ListDebtInstallments::route('/'),
+      'view' => ViewDebtInstallment::route('/{record}'),
+      'edit' => EditDebtInstallment::route('/{record}/edit'),
+    ];
+  }
 }

--- a/app/Filament/Resources/DebtInstallments/Pages/ListDebtInstallments.php
+++ b/app/Filament/Resources/DebtInstallments/Pages/ListDebtInstallments.php
@@ -1,19 +1,28 @@
 <?php
 
+/*
+ * Project Name: personal-v4
+ * File: ListDebtInstallments.php
+ * Created Date: Thursday June 25th 2026
+ * 
+ * Author: Nova Ardiansyah admin@novaardiansyah.id
+ * Website: https://novaardiansyah.id
+ * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
+ * 
+ * Copyright (c) 2026 Nova Ardiansyah, Org
+ */
+
 namespace App\Filament\Resources\DebtInstallments\Pages;
 
 use App\Filament\Resources\DebtInstallments\DebtInstallmentResource;
-use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
 
 class ListDebtInstallments extends ListRecords
 {
-    protected static string $resource = DebtInstallmentResource::class;
+  protected static string $resource = DebtInstallmentResource::class;
 
-    protected function getHeaderActions(): array
-    {
-        return [
-            CreateAction::make(),
-        ];
-    }
+  protected function getHeaderActions(): array
+  {
+    return [];
+  }
 }

--- a/app/Filament/Resources/DebtInstallments/Pages/ViewDebtInstallment.php
+++ b/app/Filament/Resources/DebtInstallments/Pages/ViewDebtInstallment.php
@@ -3,17 +3,23 @@
 namespace App\Filament\Resources\DebtInstallments\Pages;
 
 use App\Filament\Resources\DebtInstallments\DebtInstallmentResource;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewDebtInstallment extends ViewRecord
 {
-    protected static string $resource = DebtInstallmentResource::class;
+	protected static string $resource = DebtInstallmentResource::class;
 
-    protected function getHeaderActions(): array
-    {
-        return [
-            EditAction::make(),
-        ];
-    }
+	protected function getHeaderActions(): array
+	{
+		return [
+			EditAction::make(),
+			DeleteAction::make(),
+			ForceDeleteAction::make(),
+			RestoreAction::make(),
+		];
+	}
 }

--- a/app/Filament/Resources/DebtInstallments/Schemas/DebtInstallmentInfolist.php
+++ b/app/Filament/Resources/DebtInstallments/Schemas/DebtInstallmentInfolist.php
@@ -1,47 +1,99 @@
 <?php
 
+/*
+ * Project Name: personal-v4
+ * File: DebtInstallmentInfolist.php
+ * Created Date: Thursday June 25th 2026
+ * 
+ * Author: Nova Ardiansyah admin@novaardiansyah.id
+ * Website: https://novaardiansyah.id
+ * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
+ * 
+ * Copyright (c) 2026 Nova Ardiansyah, Org
+ */
+
 namespace App\Filament\Resources\DebtInstallments\Schemas;
 
 use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 
 class DebtInstallmentInfolist
 {
-    public static function configure(Schema $schema): Schema
-    {
-        return $schema
-            ->components([
-                TextEntry::make('debt_id')
-                    ->numeric(),
-                TextEntry::make('payment_id')
-                    ->numeric()
-                    ->placeholder('-'),
-                TextEntry::make('installment_number')
-                    ->numeric(),
-                TextEntry::make('due_date')
-                    ->date(),
-                TextEntry::make('principal_amount')
-                    ->numeric(),
-                TextEntry::make('interest_amount')
-                    ->numeric(),
-                TextEntry::make('service_fee')
-                    ->numeric(),
-                TextEntry::make('vat_amount')
-                    ->numeric(),
-                TextEntry::make('penalty_amount')
-                    ->numeric(),
-                TextEntry::make('total_amount')
-                    ->numeric(),
-                TextEntry::make('status'),
-                TextEntry::make('paid_at')
-                    ->dateTime()
-                    ->placeholder('-'),
-                TextEntry::make('created_at')
-                    ->dateTime()
-                    ->placeholder('-'),
-                TextEntry::make('updated_at')
-                    ->dateTime()
-                    ->placeholder('-'),
-            ]);
-    }
+  public static function configure(Schema $schema): Schema
+  {
+    return $schema
+      ->components([
+        Section::make('')
+          ->description('Installment Information')
+          ->schema([
+            TextEntry::make('debt.name')
+              ->label('Debt')
+              ->placeholder('N/A'),
+            TextEntry::make('payment.name')
+              ->label('Payment')
+              ->placeholder('-'),
+            TextEntry::make('installment_number')
+              ->label('Installment')
+							->prefix('#')
+              ->numeric(),
+            TextEntry::make('due_date')
+              ->label('Due Date')
+              ->date('M d, Y'),
+            TextEntry::make('status')
+              ->label('Status')
+              ->badge()
+              ->color(fn(string $state): string => match ($state) {
+                'paid'   => 'success',
+                'unpaid' => 'warning',
+                default  => 'primary'
+              }),
+            TextEntry::make('paid_at')
+              ->label('Paid At')
+              ->dateTime('M d, Y H:i')
+              ->placeholder('-'),
+            TextEntry::make('principal_amount')
+              ->label('Principal')
+              ->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+            TextEntry::make('interest_amount')
+              ->label('Interest')
+              ->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+            TextEntry::make('service_fee')
+              ->label('Service Fee')
+              ->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+            TextEntry::make('vat_amount')
+              ->label('VAT')
+              ->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+            TextEntry::make('penalty_amount')
+              ->label('Penalty')
+              ->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+            TextEntry::make('total_amount')
+              ->label('Total')
+              ->formatStateUsing(fn(?string $state) => toIndonesianCurrency((float) ($state ?? 0))),
+          ])
+          ->columns(['xl' => 3, '2xl' => 4])
+          ->columnSpan(['sm' => 3, 'md' => 2]),
+
+        Section::make('')
+          ->description('System Information')
+          ->schema([
+            TextEntry::make('created_at')
+              ->label('Created At')
+              ->dateTime()
+							->sinceTooltip(),
+            TextEntry::make('updated_at')
+              ->label('Last Updated')
+              ->dateTime()
+              ->sinceTooltip(),
+						TextEntry::make('deleted_at')
+							->label('Deleted At')
+							->dateTime()
+							->sinceTooltip()
+							->placeholder('N/A'),
+          ])
+          ->columns(1)
+          ->columnSpan(['sm' => 3, 'md' => 1]),
+      ])
+      ->columns(3);
+  }
 }

--- a/app/Filament/Resources/DebtInstallments/Tables/DebtInstallmentsTable.php
+++ b/app/Filament/Resources/DebtInstallments/Tables/DebtInstallmentsTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\DebtInstallments\Tables;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -15,66 +16,85 @@ class DebtInstallmentsTable
   {
     return $table
       ->columns([
+        TextColumn::make('index')
+          ->rowIndex()
+          ->label('#'),
         TextColumn::make('debt.name')
           ->label('Debt')
           ->searchable()
-          ->sortable(),
+          ->sortable()
+          ->toggleable(),
         TextColumn::make('payment.name')
           ->label('Payment')
           ->searchable()
           ->sortable()
-          ->placeholder('-'),
+          ->placeholder('-')
+          ->toggleable(isToggledHiddenByDefault: true),
         TextColumn::make('installment_number')
-          ->label('Installment #')
+          ->label('Installment')
           ->numeric()
-          ->sortable(),
-        TextColumn::make('due_date')
-          ->label('Due Date')
-          ->date('M d, Y')
-          ->sortable(),
+          ->sortable()
+          ->toggleable()
+					->prefix('#'),
         TextColumn::make('principal_amount')
           ->label('Principal')
           ->sortable()
-          ->formatStateUsing(fn($state) => toIndonesianCurrency($state)),
+          ->formatStateUsing(fn($state) => toIndonesianCurrency($state))
+          ->toggleable(isToggledHiddenByDefault: true),
         TextColumn::make('interest_amount')
           ->label('Interest')
           ->sortable()
-          ->formatStateUsing(fn($state) => toIndonesianCurrency($state)),
+          ->formatStateUsing(fn($state) => toIndonesianCurrency($state))
+          ->toggleable(isToggledHiddenByDefault: true),
         TextColumn::make('service_fee')
           ->label('Service Fee')
           ->sortable()
-          ->formatStateUsing(fn($state) => toIndonesianCurrency($state)),
+          ->formatStateUsing(fn($state) => toIndonesianCurrency($state))
+          ->toggleable(isToggledHiddenByDefault: true),
         TextColumn::make('vat_amount')
           ->label('VAT')
           ->sortable()
-          ->formatStateUsing(fn($state) => toIndonesianCurrency($state)),
+          ->formatStateUsing(fn($state) => toIndonesianCurrency($state))
+          ->toggleable(isToggledHiddenByDefault: true),
         TextColumn::make('penalty_amount')
           ->label('Penalty')
           ->sortable()
-          ->formatStateUsing(fn($state) => toIndonesianCurrency($state)),
+          ->formatStateUsing(fn($state) => toIndonesianCurrency($state))
+          ->toggleable(isToggledHiddenByDefault: true),
         TextColumn::make('total_amount')
           ->label('Total')
           ->sortable()
-          ->formatStateUsing(fn($state) => toIndonesianCurrency($state)),
+          ->formatStateUsing(fn($state) => toIndonesianCurrency($state))
+          ->toggleable(),
         TextColumn::make('status')
           ->label('Status')
           ->badge()
           ->color(fn(string $state): string => match ($state) {
-            'paid' => 'success',
+            'paid'   => 'success',
             'unpaid' => 'warning',
-            default => 'primary'
+            default  => 'primary'
           }),
+				TextColumn::make('due_date')
+          ->label('Due Date')
+          ->date('M d, Y')
+          ->sortable()
+          ->toggleable()
+					->sinceTooltip(),
         TextColumn::make('paid_at')
           ->label('Paid At')
           ->dateTime('M d, Y H:i')
-          ->sortable(),
+          ->sortable()
+          ->toggleable(),
       ])
+			->recordAction(null)
+			->recordUrl(null)
       ->filters([
-        //
       ])
       ->recordActions([
-        ViewAction::make(),
-        EditAction::make(),
+        ActionGroup::make([
+          ViewAction::make(),
+          EditAction::make(),
+        ])
       ])
       ->toolbarActions([
         BulkActionGroup::make([

--- a/app/Filament/Resources/Debts/DebtResource.php
+++ b/app/Filament/Resources/Debts/DebtResource.php
@@ -69,10 +69,10 @@ class DebtResource extends Resource
 	public static function getPages(): array
 	{
 		return [
-			'index' => ListDebts::route('/'),
+			'index'  => ListDebts::route('/'),
 			'create' => CreateDebt::route('/create'),
-			'view' => ViewDebt::route('/{record}'),
-			'edit' => EditDebt::route('/{record}/edit'),
+			'view'   => ViewDebt::route('/{record}'),
+			'edit'   => EditDebt::route('/{record}/edit'),
 		];
 	}
 

--- a/app/Filament/Resources/Debts/RelationManagers/InstallmentsRelationManager.php
+++ b/app/Filament/Resources/Debts/RelationManagers/InstallmentsRelationManager.php
@@ -4,11 +4,11 @@
  * Project Name: personal-v4
  * File: InstallmentsRelationManager.php
  * Created Date: Thursday June 25th 2026
- * 
+ *
  * Author: Nova Ardiansyah admin@novaardiansyah.id
  * Website: https://novaardiansyah.id
  * MIT License: https://github.com/novaardiansyah/personal-v4/blob/main/LICENSE
- * 
+ *
  * Copyright (c) 2026 Nova Ardiansyah, Org
  */
 
@@ -20,6 +20,7 @@ use App\Models\PaymentAccount;
 use App\Models\PaymentType;
 use App\Models\Payment;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -39,52 +40,54 @@ class InstallmentsRelationManager extends RelationManager
 
 		return $table
 			->columns($columns)
-			->defaultSort('installment_number', 'asc')
+			->defaultSort('installment_number', 'desc')
 			->actions([
-				Action::make('pay')
-					->label('Pay')
-					->icon('heroicon-o-credit-card')
-					->color('success')
-					->visible(fn(DebtInstallment $record) => $record->status === 'unpaid')
-					->form([
-						Select::make('payment_account_id')
-							->label('Source Account')
-							->options(PaymentAccount::where('user_id', auth()->id())->pluck('name', 'id'))
-							->required()
-							->native(false),
-					])
-					->action(function (DebtInstallment $record, array $data): void {
-						try {
-							$payment = Payment::create([
-								'type_id'            => PaymentType::EXPENSE,
-								'user_id'            => auth()->id(),
-								'payment_account_id' => $data['payment_account_id'],
-								'name'               => 'Bayar Cicilan ke-' . $record->installment_number . ': ' . $record->debt->platform_name . ' - ' . $record->debt->name,
-								'amount'             => $record->total_amount,
-								'date'               => Carbon::now(),
-								'is_draft'           => false,
-								'is_scheduled'       => false,
-							]);
+				ActionGroup::make([
+					Action::make('pay')
+						->label('Pay')
+						->icon('heroicon-o-credit-card')
+						->color('success')
+						->visible(fn(DebtInstallment $record) => $record->status === 'unpaid')
+						->form([
+							Select::make('payment_account_id')
+								->label('Source Account')
+								->options(PaymentAccount::where('user_id', auth()->id())->pluck('name', 'id'))
+								->required()
+								->native(false),
+						])
+						->action(function (DebtInstallment $record, array $data): void {
+							try {
+								$payment = Payment::create([
+									'type_id'            => PaymentType::EXPENSE,
+									'user_id'            => auth()->id(),
+									'payment_account_id' => $data['payment_account_id'],
+									'name'               => 'Bayar Cicilan ke-' . $record->installment_number . ': ' . $record->debt->platform_name . ' - ' . $record->debt->name,
+									'amount'             => $record->total_amount,
+									'date'               => Carbon::now(),
+									'is_draft'           => false,
+									'is_scheduled'       => false,
+								]);
 
-							$record->update([
-								'status'     => 'paid',
-								'paid_at'    => Carbon::now(),
-								'payment_id' => $payment->id,
-							]);
+								$record->update([
+									'status'     => 'paid',
+									'paid_at'    => Carbon::now(),
+									'payment_id' => $payment->id,
+								]);
 
-							Notification::make()
-								->success()
-								->title('Payment Recorded')
-								->body('The installment payment has been successfully recorded.')
-								->send();
-						} catch (\Exception $e) {
-							Notification::make()
-								->danger()
-								->title('Payment Failed')
-								->body($e->getMessage())
-								->send();
-						}
-					}),
+								Notification::make()
+									->success()
+									->title('Payment Recorded')
+									->body('The installment payment has been successfully recorded.')
+									->send();
+							} catch (\Exception $e) {
+								Notification::make()
+									->danger()
+									->title('Payment Failed')
+									->body($e->getMessage())
+									->send();
+							}
+						}),
+				])
 			]);
 	}
 }


### PR DESCRIPTION
- Display the index column in the installments table.
- Hide default columns such as debt, payment, principal, interest, service fee, vat, and penalty by default.
- Group table actions into an action group.
- Disable create action and form for installments.
- Reformat the infolist to organize fields into sections.